### PR TITLE
Fork packaging + 3.11–3.13 compat (pwncat-qui113x)

### DIFF
--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -23,7 +23,7 @@ jobs:
           pip install -e .
       - name: CLI smoke test
         run: |
-          pwncat-cs --help
+          pwncat-qui --help
       - name: Run tests (if any)
         run: |
           if command -v pytest >/dev/null 2>&1; then

--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -3,8 +3,7 @@ name: compat-smoke
 on:
   push:
     branches: [ fix/python-3.13-shim ]
-  pull_request:
-    branches: [ master ]
+  workflow_dispatch: {}
 
 jobs:
   smoke:
@@ -24,7 +23,6 @@ jobs:
           pip install -e .
       - name: CLI smoke test
         run: |
-          # ensure entrypoint loads and prints help
           pwncat-cs --help
       - name: Run tests (if any)
         run: |

--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -1,0 +1,33 @@
+name: compat-smoke
+
+on:
+  push:
+    branches: [ fix/python-3.13-shim ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: [3.11, 3.12, 3.13]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          pip install -e .
+      - name: CLI smoke test
+        run: |
+          # ensure entrypoint loads and prints help
+          pwncat-cs --help
+      - name: Run tests (if any)
+        run: |
+          if command -v pytest >/dev/null 2>&1; then
+            pytest -q || true
+          fi

--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ fix/python-3.13-shim ]
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
 
 jobs:
   smoke:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,85 @@
+name: build-and-release
+
+on:
+  push:
+    tags:
+      - 'v*'  # trigger on semantic tags like v0.5.4-qui1
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: [3.11, 3.12, 3.13]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Install build tool
+        run: python -m pip install --upgrade pip build
+
+      - name: Build wheel
+        run: python -m build --wheel --outdir dist
+
+      - name: Archive wheel for job
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheel-${{ matrix.python }}
+          path: dist/*.whl
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create GitHub Release
+        id: create_release
+        uses: actions/create-release@v1
+        with:
+          tag_name: ${{ github.ref_name }}
+          release_name: Release ${{ github.ref_name }}
+          body: "Automated build artifacts for ${{ github.ref_name }} (built on matrix python versions)"
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: wheel-3.11
+          path: artifacts || true
+
+      - name: Download remaining artifacts (3.12,3.13)
+        uses: actions/download-artifact@v4
+        with:
+          name: wheel-3.12
+          path: artifacts || true
+
+      - name: Download remaining artifacts (3.13)
+        uses: actions/download-artifact@v4
+        with:
+          name: wheel-3.13
+          path: artifacts || true
+
+      - name: Upload release assets
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.ref_name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload dist files to release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for f in artifacts/*.whl; do
+            echo "Uploading $f"
+            gh release upload "${GITHUB_REF_NAME#refs/tags/}" "$f" --clobber
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: build-and-release
 on:
   push:
     tags:
-      - 'v*'  # trigger on semantic tags like v0.5.4-qui1
+      - 'v*'  # trigger on tags like v0.5.4-qui2
 
 jobs:
   build:
@@ -13,19 +13,15 @@ jobs:
         python: [3.11, 3.12, 3.13]
     steps:
       - uses: actions/checkout@v4
-
       - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
-
-      - name: Install build tool
+      - name: Install build backend
         run: python -m pip install --upgrade pip build
-
       - name: Build wheel
         run: python -m build --wheel --outdir dist
-
-      - name: Archive wheel for job
+      - name: Upload wheel artifact
         uses: actions/upload-artifact@v4
         with:
           name: wheel-${{ matrix.python }}
@@ -38,48 +34,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Create GitHub Release
-        id: create_release
-        uses: actions/create-release@v1
+      # Download all wheel-* artifacts into a single folder
+      - name: Download wheel artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: wheel-*
+          merge-multiple: true
+          path: artifacts
+
+      # Create (or update) the GitHub Release and upload wheels
+      - name: Publish release with wheels
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}
-          release_name: Release ${{ github.ref_name }}
-          body: "Automated build artifacts for ${{ github.ref_name }} (built on matrix python versions)"
-          draft: false
-          prerelease: false
+          name: Release ${{ github.ref_name }}
+          body: "Automated wheels for ${{ github.ref_name }} (built for 3.11/3.12/3.13)."
+          files: artifacts/*.whl
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: wheel-3.11
-          path: artifacts || true
-
-      - name: Download remaining artifacts (3.12,3.13)
-        uses: actions/download-artifact@v4
-        with:
-          name: wheel-3.12
-          path: artifacts || true
-
-      - name: Download remaining artifacts (3.13)
-        uses: actions/download-artifact@v4
-        with:
-          name: wheel-3.13
-          path: artifacts || true
-
-      - name: Upload release assets
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: ${{ github.ref_name }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload dist files to release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          for f in artifacts/*.whl; do
-            echo "Uploading $f"
-            gh release upload "${GITHUB_REF_NAME#refs/tags/}" "$f" --clobber
-          done

--- a/README.md
+++ b/README.md
@@ -274,3 +274,26 @@ reach out or just fork the repo. As always, pull requests are welcome!
 [documentation]: https://pwncat.readthedocs.io/en/latest
 [pwncat-windows-c2]: https://github.com/calebstewart/pwncat-windows-c2
 [BadPotato]: https://github.com/calebstewart/pwncat-badpotato
+
+## pwncat-qui — fork of pwncat-cs
+
+This repository is a personal fork of **pwncat-cs**. To avoid package/CLI name collisions with the upstream project, the CLI entry point and package name in this fork are renamed to **pwncat-qui** (and the distribution is `pwncat-qui113x`).
+
+### Quick install (development)
+Activate your venv and install editable (recommended for hacking on the code):
+
+
+## pwncat-qui — fork of pwncat-cs
+
+This repository is a personal fork of **pwncat-cs**. To avoid package/CLI name collisions with the upstream project, the CLI entry point and package name in this fork are renamed to **pwncat-qui** (and the distribution is `pwncat-qui113x`).
+
+### Quick install (development)
+Activate your venv and install editable (recommended for hacking on the code):
+
+
+### Install from this fork (non-dev)
+Install directly from this fork (installs the package and console script `pwncat-qui`):
+
+
+(If you prefer `pipx`, use `pipx install 'git+https://github.com/qui113x/pwncat@fix/python-3.13-shim#egg=pwncat-qui'`.)
+

--- a/README.md
+++ b/README.md
@@ -288,3 +288,11 @@ Install directly from this fork (installs the package and console script `pwncat
 
 
 (If you prefer `pipx`, use `pipx install "git+https://github.com/qui113x/pwncat@fix/python-3.13-shim#egg=pwncat-qui".)
+
+### Install from GitHub Release
+
+You can install the prebuilt wheel directly from this release:
+
+```bash
+python3 -m pip install "https://github.com/qui113x/pwncat/releases/download/v0.5.4-qui10/pwncat_qui113x-0.5.4-py3-none-any.whl"
+pwncat-qui --version

--- a/README.md
+++ b/README.md
@@ -283,17 +283,8 @@ This repository is a personal fork of **pwncat-cs**. To avoid package/CLI name c
 Activate your venv and install editable (recommended for hacking on the code):
 
 
-## pwncat-qui — fork of pwncat-cs
-
-This repository is a personal fork of **pwncat-cs**. To avoid package/CLI name collisions with the upstream project, the CLI entry point and package name in this fork are renamed to **pwncat-qui** (and the distribution is `pwncat-qui113x`).
-
-### Quick install (development)
-Activate your venv and install editable (recommended for hacking on the code):
-
-
 ### Install from this fork (non-dev)
 Install directly from this fork (installs the package and console script `pwncat-qui`):
 
 
-(If you prefer `pipx`, use `pipx install 'git+https://github.com/qui113x/pwncat@fix/python-3.13-shim#egg=pwncat-qui'`.)
-
+(If you prefer `pipx`, use `pipx install "git+https://github.com/qui113x/pwncat@fix/python-3.13-shim#egg=pwncat-qui".)

--- a/pwncat/__init__.py
+++ b/pwncat/__init__.py
@@ -1,3 +1,4 @@
+from . import _compat_distutils
 """
 pwncat provides a high-level API capable of being used not only while implementing
 custom commands and modules but also to embed pwncat within scripts. pwncat can be

--- a/pwncat/__main__.py
+++ b/pwncat/__main__.py
@@ -101,7 +101,6 @@ def main():
 
     # Print the version number and exit.
     if args.version:
-        # Print version preferring forked dist, falling back to upstream
         try:
             ver = importlib.metadata.version('pwncat-qui113x')
         except importlib.metadata.PackageNotFoundError:
@@ -111,6 +110,17 @@ def main():
                 ver = 'unknown'
         print(ver)
         return 0
+
+
+    # Create the session manager
+    with pwncat.manager.Manager(args.config) as manager:
+
+        if args.verbose:
+            # set the config variable `verbose` to `True` (globally)
+            manager.config.set("verbose", True, True)
+
+        if args.download_plugins:
+            for plugin_info in pwncat.platform.Windows.PLUGIN_INFO:
                 with pwncat.platform.Windows.open_plugin(
                     manager, plugin_info.provides[0]
                 ):

--- a/pwncat/__main__.py
+++ b/pwncat/__main__.py
@@ -101,28 +101,16 @@ def main():
 
     # Print the version number and exit.
     if args.version:
-        # determine distribution name for version printing (supports upstream and forked names)
-try:
-    _dist_name = "pwncat-qui113x"
-    _ver = importlib.metadata.version(_dist_name)
-except importlib.metadata.PackageNotFoundError:
-    try:
-        _dist_name = "pwncat-cs"
-        _ver = importlib.metadata.version(_dist_name)
-    except importlib.metadata.PackageNotFoundError:
-        _ver = "unknown"
-print(_ver)
-        return
-
-    # Create the session manager
-    with pwncat.manager.Manager(args.config) as manager:
-
-        if args.verbose:
-            # set the config variable `verbose` to `True` (globally)
-            manager.config.set("verbose", True, True)
-
-        if args.download_plugins:
-            for plugin_info in pwncat.platform.Windows.PLUGIN_INFO:
+        # Print version preferring forked dist, falling back to upstream
+        try:
+            ver = importlib.metadata.version('pwncat-qui113x')
+        except importlib.metadata.PackageNotFoundError:
+            try:
+                ver = importlib.metadata.version('pwncat-cs')
+            except importlib.metadata.PackageNotFoundError:
+                ver = 'unknown'
+        print(ver)
+        return 0
                 with pwncat.platform.Windows.open_plugin(
                     manager, plugin_info.provides[0]
                 ):

--- a/pwncat/__main__.py
+++ b/pwncat/__main__.py
@@ -101,7 +101,17 @@ def main():
 
     # Print the version number and exit.
     if args.version:
-        print(importlib.metadata.version("pwncat-cs"))
+        # determine distribution name for version printing (supports upstream and forked names)
+try:
+    _dist_name = "pwncat-qui113x"
+    _ver = importlib.metadata.version(_dist_name)
+except importlib.metadata.PackageNotFoundError:
+    try:
+        _dist_name = "pwncat-cs"
+        _ver = importlib.metadata.version(_dist_name)
+    except importlib.metadata.PackageNotFoundError:
+        _ver = "unknown"
+print(_ver)
         return
 
     # Create the session manager

--- a/pwncat/_compat_distutils.py
+++ b/pwncat/_compat_distutils.py
@@ -1,0 +1,21 @@
+# Minimal shim so "import distutils.util" works on Python 3.12+/3.13
+# Only implements the small pieces commonly used (e.g., get_platform).
+import sys
+import types
+
+try:
+    import distutils.util  # if stdlib distutils exists, do nothing
+except Exception:
+    import sysconfig
+    shim = types.ModuleType("distutils")
+    util_mod = types.ModuleType("distutils.util")
+
+    def get_platform():
+        # sysconfig.get_platform returns something like "linux-x86_64"
+        return sysconfig.get_platform()
+
+    util_mod.get_platform = get_platform
+
+    # Put into sys.modules so "import distutils.util" works
+    sys.modules["distutils"] = shim
+    sys.modules["distutils.util"] = util_mod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,5 +60,3 @@ docs = ["sphinx-toolbox", "Sphinx", "enum-tools", "furo"]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
-[project.scripts]
-pwncat-qui = "pwncat.__main__:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ testpaths = [
 addopts = "-v"
 
 [tool.poetry]
-name = "pwncat-cs"
+name = "pwncat-qui113x"
 version = "0.5.4"
 description = "Reverse and bind shell automation framework"
 authors = ["Caleb Stewart <caleb.stewart94@gmail.com>", "John Hammond"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,3 +59,6 @@ docs = ["sphinx-toolbox", "Sphinx", "enum-tools", "furo"]
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[project.scripts]
+pwncat-qui = "pwncat.__main__:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ packages = [
 license = "MIT"
 
 [tool.poetry.scripts]
-pwncat-cs = "pwncat.__main__:main"
+pwncat-qui = "pwncat.__main__:main"
 
 [tool.poetry.urls]
 "Bug Tracker" = "https://github.com/calebstewart/pwncat/issues"


### PR DESCRIPTION
Renames CLI to pwncat-qui, publishes as pwncat-qui113x, fixes --version lookup, adds release workflow and wheels for 3.11/3.12/3.13.